### PR TITLE
[#88974624] Fix iOS 8 dispatching native clicks shortly after fastclick

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -599,10 +599,11 @@
 			//If the touch lasted longer than ~125ms, iOS 8 will also dispatch
 			//a native click event. We should shut this one up; e.preventDefault
 			//also doesn't cut it.
-			var clickListener = function (ev) {
+			var clickListener = function clickListener(ev) {
 				if (!ev.forwardedTouchEvent) {
 					ev.preventDefault();
 					ev.stopPropagation();
+					targetElement.removeEventListener('click', clickListener);
 					return false;
 				}
 			};

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -596,6 +596,22 @@
 		//	-#2: If your label has stuff in it to be clicked, the nested stuff needs to have pointer-events: none
 		//			so that the label recieves the click directly.
 		if (targetLabel !== null) {
+			//If the touch lasted longer than ~125ms, iOS 8 will also dispatch
+			//a native click event. We should shut this one up; e.preventDefault
+			//also doesn't cut it.
+			var clickListener = function (ev) {
+				if (!ev.forwardedTouchEvent) {
+					ev.preventDefault();
+					ev.stopPropagation();
+					return false;
+				}
+			};
+			//Add the event listener in the capture phase, to cancel it before
+			//anything else hears it
+			targetElement.addEventListener('click', clickListener, true);
+			setTimeout(function(){
+				targetElement.removeEventListener('click', clickListener);
+			}, 310);
 			event.preventDefault();
 			this.sendClick(targetLabel, event);
 			return false;


### PR DESCRIPTION
If a click is a long click, then iOS 8 will dispatch a native click
which cannot be cancelled. This is causing our checkboxes to be checked
twice for medium-length clicks. This listens for and cancels this native
click.

See https://github.com/ftlabs/fastclick/issues/262
