### PR TITLE
Properly remove click supressor listener on iOS8

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -598,7 +598,6 @@
                 isLabelWithSyntheticClick = true;
             }
         } else if (this.needsFocus(targetElement)) {
-
             // Case 1: If the touch started a while ago (best guess is 100ms based on tests for issue #36) then focus will be triggered anyway. Return early and unset the target element reference so that the subsequent click will be allowed through.
             // Case 2: Without this exception for input elements tapped when the document is contained in an iframe, then any inputted text won't be visible even though the value attribute is updated as the user types (issue #37).
             if ((event.timeStamp - trackingClickStart) > 100 || (deviceIsIOS && window.top !== window && targetTagName === 'input')) {
@@ -640,14 +639,14 @@
                     if (!ev.forwardedTouchEvent) {
                         ev.preventDefault();
                         ev.stopPropagation();
-                        targetElement.removeEventListener('click', clickListener);
+                        targetElement.removeEventListener('click', clickListener, true);
                     }
                 };
                 //Add the event listener in the capture phase, to cancel it before
                 //anything else hears it
                 targetElement.addEventListener('click', clickListener, true);
                 setTimeout(function(){
-                    targetElement.removeEventListener('click', clickListener);
+                    targetElement.removeEventListener('click', clickListener, true);
                 }, 310);
             }
             event.preventDefault();


### PR DESCRIPTION
The handler was getting registered as capture, so needs to be removed
specifying the capture phase too. These click supressor listeners were
hanging around and breaking shit.
