### PR TITLE
Make fastclick work on iOS 8 simulator

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -211,7 +211,10 @@
      */
     var deviceIsIOSWithBadTarget = deviceIsIOS && (/OS [6-7]_\d/).test(navigator.userAgent);
 
-    var deviceIsIOSWithNoLongTapDelay = deviceIsIOS && (/OS 8_\d/).test(navigator.userAgent);
+    var deviceIsIOSWithNoLongTapDelay = deviceIsIOS && ((/OS 8_\d/).test(navigator.userAgent)
+                                            //WTF the iOS simulator returns the OSX version it's running on
+                                            || ((/OS 10_10_\d/).test(navigator.userAgent) &&
+                                                (/Version\/8/).test(navigator.userAgent)));
 
     /**
      * BlackBerry requires exceptions.


### PR DESCRIPTION
The useragent string for it is seriously broke
